### PR TITLE
Added Key and/or Key-Value in Veb tree

### DIFF
--- a/src/veb_tree.rs
+++ b/src/veb_tree.rs
@@ -191,7 +191,7 @@ where
                             nodes.push((*nodes[i]).parent)
                         }
                     }
-                    NodeType::Leaf(_) => panic!("Should not reach hear"),
+                    NodeType::Leaf(_) => panic!("Should not reach here"),
                 }
             }
             i += 1;


### PR DESCRIPTION
So that it supports kind of binary search.

I'll add a search method later.

To make a b-tree, we still need a "blackbox" (packed memory array) behind it.